### PR TITLE
デプロイエラー対応、harmonyを有効に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
デプロイエラーが発生したため、エラー文に従ってharmonyを有効に変更した

# エラー画像キャプチャ
[![Image from Gyazo](https://i.gyazo.com/806cdc00299f247d6e6c3555f1bb3d51.png)](https://gyazo.com/806cdc00299f247d6e6c3555f1bb3d51)

参考　Qiita
https://qiita.com/terufumi1122/items/27bf288414569e13e050