### PR TITLE
本番環境でのフリマのロゴが表示されない不具合を解消する

### DIFF
--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,6 +1,6 @@
 .header
   .header__icon
-    = image_tag '/assets/logo/logo.png', :size =>'185x49'
+    = image_tag asset_path('logo/logo.png'), :size =>'185x49'
 
 .buyconfirm
   = form_with url: buy_product_path, method: :post, local: true do |f| 


### PR DESCRIPTION
# What
ローカルではフリマのロゴが正常に表示されるが、
本番環境ではフリマのロゴが正常に表示されないため、
表示できるようにする

# Why
本番環境と開発環境の違いは
・パスが変わること
・画像名が変わること
それに対応をするために、asset_path()を使うと良いらしい
本当にロゴが表示できるかわからないため、購入確認画面のロゴ表示の書き方のみ変更してみて
マージしデプロイして本番環境でロゴが表示できるかどうか試してみる。

### 参考
https://railsguides.jp/asset_pipeline.html
https://t-salad.com/rails-image-show/
https://qiita.com/koda_7932/items/3fc65043de97a1b5cd61