### PR TITLE
product_destroy

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -211,6 +211,9 @@ $(function () {
         .fail(function (XMLHttpRequest, textStatus, errorThrown) {
           alert('出品に失敗しました！');
         })
+        .always(function () {
+          $(".submit").removeAttr("disabled")
+        }) 
     } else if ($(this).attr('class') == "edit_item") {
       $.ajax({
         url: url,
@@ -225,7 +228,10 @@ $(function () {
         })
         .fail(function (XMLHttpRequest, textStatus, errorThrown) {
           alert('出品に失敗しました！！');
-        });
+        })
+        .always(function () {
+          $(".submit").removeAttr("disabled")
+        }) 
     }
   });
    // 手数料計算機能

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -100,10 +100,12 @@ class ProductsController < ApplicationController
   end
 
   def destroy
+    @product = Product.find(params[:id])
+    @products = Product.includes(:pictures).order('created_at DESC')
     if @product.destroy
       redirect_to products_path
     else
-      render :index
+      # render :index
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -10,8 +10,8 @@ class Product < ApplicationRecord
   # validates :pictures, presence: true
 
   belongs_to :user
-  belongs_to :saler, class_name: "User", optional: true, dependent: :destroy
-  belongs_to :buyer, class_name: "User", optional: true, dependent: :destroy
+  belongs_to :saler, class_name: "User", optional: true
+  belongs_to :buyer, class_name: "User", optional: true
   belongs_to :category
   has_many :pictures, dependent: :destroy
 

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -123,7 +123,7 @@
   </div>
   <div class="productsale__main__containers__save">
     <div class="productsale__main__containers__save__submit">
-      <%= f.submit "出品する" %>
+      <%= f.submit "出品する", class: "submit" %>
     </div>
     <div class="productsale__main__containers__save__draft">
       <%#= f.submit "下書きに保存" %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -134,7 +134,7 @@
     </div>
   <div class="productsale__main__containers__save">
     <div class="productsale__main__containers__save__submit">
-      <%= f.submit "編集する" %>
+      <%= f.submit "編集する", class: "submit"%>
     </div>
     <div class="productsale__main__containers__save__draft">
       <%#= f.submit "下書きに保存" %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -126,7 +126,7 @@
   </div>
   <div class="productsale__main__containers__save">
     <div class="productsale__main__containers__save__submit">
-      <%= f.submit "出品する" %>
+      <%= f.submit "出品する",class: "submit" %>
     </div>
     <div class="productsale__main__containers__save__draft">
       <%#= f.submit "下書きに保存" %>


### PR DESCRIPTION
#WHY
商品の削除機能の実装
商品出品、編集時のエラー時にform再送信ができないバグの解消

#WHAT
商品の削除機能の実装
商品出品、編集時のエラー時のform送信”disable”の解消

#ADDITIONAL
チームの方針でhtmlで実装し、最後にhaml変換予定です。
また、_form, new, edit全てを修正していますが、最終的には_formに統合する予定です（現時点ではまだ統合していません）。