### PR TITLE
user_profileマークアップとcards登録の紐付け

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,4 @@
 @import "show";
 @import "purchase";
 @import "cards";
+@import "mypage";

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -1,0 +1,321 @@
+body {
+  margin: 0 auto;
+  height: 100vh;
+  
+}
+.container {
+  width: 1020px;
+  padding:0 0 40px;
+  margin: 40px auto 0;
+  
+  .left-content{
+    float: right;
+    width: 700px;
+    background-color: #ffffff;
+    .mypage-user-icon{
+      height: 200px;
+      position: relative;
+      padding :20px; 
+      &__box {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        -webkit-transform: translate(0, -50%);
+        transform: translate(0, -50%);
+        color: #333;
+        text-decoration: none;
+        figure{
+          overflow: hidden;
+          width: 60px;
+          height: 60px;
+          margin: 0 auto;
+          border-radius: 50%;
+        }
+      
+        h2{
+          margin: 8px 0 0;
+          font-size: 14px;  
+          text-align: center;
+          color: #333;
+        }
+        .mypage-number {
+          margin: 8px 0 0;
+          font-size: 14px;
+          text-align: center;
+          
+          div {
+            display: inline-block;
+            
+          }
+          div+div{
+            margin: 0 0 0 16px
+          }
+        }
+      }
+    }
+    .mypage-tab-container-notification-todo{
+
+      ul.mypage-tabs{
+        height: 72px;
+        display: flex;
+        line-height: 72px;
+        text-align: center;
+        li{
+          background-color: gray;
+          width: 50%;
+         
+          h3 {
+          
+            a{
+              font-size: 16px;
+              text-decoration: none;
+              color: #333;
+            }
+          }
+        }
+        .active {
+          background-color: #fff;
+          
+        }
+      }
+      .tab-content{
+        .tab-pane.active{
+          display: block;
+        }
+        .mypage-item-list{
+
+        
+          li:first-child {
+            border-bottom: 1px solid #eee;
+          } 
+          .li:last-child {
+            border: 0;
+          }
+          .mypage-item-link{
+            display: block;
+            min-height: 80px;
+            padding: 16px;
+            color: #333;
+            border-bottom: 1px solid #eee;
+            position: relative;
+            text-decoration: none;
+            figure{
+              position: absolute;
+              position: relative;
+              overflow: hidden;
+              float: left;
+              width: 48px;
+              height: 48px;
+              margin : 0;
+              img{
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                z-index: 1;
+                width: 100%;
+              }
+            }
+            .mypage-item-body{
+              margin: 0px 40px 0px 68px;
+              
+              .mypage-item-text{
+                overflow: hidden;
+                display: block;
+                display: -webkit-box;
+                max-height: 4.4em;
+                -webkit-line-clamp: 3;
+                -webkit-box-orient: vertical;
+                text-overflow: ellipsis;
+                line-height: 1.5;
+                text-decoration: none;
+
+              }
+            }
+          }
+          .mypage-go-list{
+            padding: 16px;
+            a {
+              display: block;
+              height: 56px;
+              margin: 0 auto;
+              background: #eee;
+              color: #333;
+              line-height: 56px;
+              text-align: center;
+            }
+          }
+        }
+        .tab-pane {
+          display: none;
+       }
+      }
+    }
+    .mypage-tab-container{
+      
+      h2 {
+      
+      }
+      .mypage-tab-head {
+        padding: 0 16px;
+        background: #fafafa;
+        font-size: 16px;
+        line-height: 72px;
+        color:#333;
+      }
+      ul.mypage-tabs{
+        height: 72px;
+        display: flex;
+        line-height: 72px;
+        text-align: center;
+        li{
+          background-color: gray;
+          width: 50%;
+         
+          h3 {
+          
+            a{
+              font-size: 16px;
+              text-decoration: none;
+              color: #333;
+            }
+          }
+        }
+        .active {
+          background-color: #fff;
+          
+        }
+      }
+      .tab-content{
+        .tab-pane.active{
+            display: block;
+        
+          .mypage-item-not-found{
+            padding: 160px 0 60px;
+              background: url(/jp/assets/img/common/common/logo-gray-icon.svg?7920313);
+              background-repeat: no-repeat;
+              background-position: center 40px;
+              background-size: 78px 85px;
+              text-align: center;
+              font-size: 16px;
+              color: #ccc;
+          }
+        } 
+        /*.tab-pane.active{
+          display: block;
+        }
+        .mypage-item-list{
+          li:first-child {
+            border-bottom: 1px solid #eee;
+          } 
+          .li:last-child {
+            border: 0;
+          }
+          .mypage-item-link{
+            display: block;
+            min-height: 80px;
+            padding: 16px;
+            color: #333;
+            border-bottom: 1px solid #eee;
+            position: relative;
+            figure{
+              position: absolute;
+              position: relative;
+              overflow: hidden;
+              float: left;
+              width: 48px;
+              height: 48px;
+              margin : 0;
+              img{
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                z-index: 1;
+                width: 100%;
+              }
+            }
+            .mypage-item-body{
+              margin: 0 40px 0 68px;
+              .mypage-item-text{
+                overflow: hidden;
+                display: block;
+                display: -webkit-box;
+                max-height: 4.4em;
+                -webkit-line-clamp: 3;
+                -webkit-box-orient: vertical;
+                text-overflow: ellipsis;
+                line-height: 1.5;
+
+              }
+            }
+          }
+          .mypage-go-list{
+            padding: 16px;
+            a {
+              display: block;
+              height: 56px;
+              margin: 0 auto;
+              background: #eee;
+              color: #333;
+              line-height: 56px;
+              text-align: center;
+            }
+          }
+        }*/
+
+        .tab-pane {
+          display: none;
+       }
+      }
+    
+    }
+
+  }
+  
+  .right-content{
+    float: left;
+    width: 280px;
+    margin: 0 40px 0 0;
+    .mypage-nav {
+      .mypage-nav-list{
+        list-style: none;
+        margin: 0;
+        .li:first-child {
+          border: 0;
+        }
+        li {
+          height: 80px;
+          border-top: 1px solid #eee;
+        }
+        .mypage-nav-list-item{
+          text-decoration: none;
+          position: relative;
+          min-height: 48px;
+          display: block;
+          padding: 16px;
+          background: #fff;
+          font-size: 14px;
+          color: #333;
+          .active{
+            background: #eee;
+            font-weight: 600;
+          }
+        }
+      }
+      .mypage-nav-head {
+        margin: 40px 0 0;
+      
+      }
+      .mypage-nav-head+.mypage-nav-list{
+        margin: 8px 0 0;
+      }
+    }
+  }
+  
+}
+
+

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -10,7 +10,7 @@
 */
 html{
   color:#000;
-  background:#FFF;
+  background:#F5F5F5;
 }
 /*
   TODO remove settings on BODY since we can't namespace it.

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,7 +3,8 @@ class CardsController < ApplicationController
   before_action :set_card, only: [:new, :destroy]
   before_action :set_payjp_secretkey, except: :new
 
-  def index #Cardのデータpayjpに送り情報を取り出します
+  def index #Cardのデータpayjpに送り情報を取り出します]
+    
     @card = Card.where(user_id: current_user.id).first
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
@@ -48,6 +49,7 @@ class CardsController < ApplicationController
     end
   end
   def destroy #PayjpとCardデータベースを削除します
+    
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -49,13 +49,19 @@ class CardsController < ApplicationController
     end
   end
   def destroy #PayjpとCardデータベースを削除します
-    
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete
       @card.delete
+      if @card.destroy 
+        redirect_to user_cards_path 
+        flash[:notice] = "クレジットカードを削除しました。"
+      else
+        redirect_to user_cards_path 
+        flash[:alert] = "クレジットカードを削除できませんでした。"
+      end
     end
-      redirect_to action: "index"
+      
   end
 
   private

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -52,7 +52,6 @@ class CardsController < ApplicationController
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete
-      @card.delete
       if @card.destroy 
         redirect_to user_cards_path 
         flash[:notice] = "クレジットカードを削除しました。"

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,7 +5,7 @@ class CardsController < ApplicationController
 
   def index #Cardのデータpayjpに送り情報を取り出します]
     
-    @card = Card.where(user_id: current_user.id).first
+    @card = Card.find_by(user_id: current_user.id)
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
       @card_information = customer.cards.retrieve(@card.card_id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @address = Address.where(user_id: current_user.id)
+    @address = Address.find_by(user_id: current_user.id)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,9 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :logout]
-  before_action :set_address, only: [:edit, :update]
-
-  def
+  
 
   def show
+    @user = User.find(params[:id])
+    @address = Address.where(user_id: current_user.id)
   end
 
   def edit
@@ -22,11 +21,5 @@ class UsersController < ApplicationController
   
 
   private
-  def set_user
-    @user = User.find(params[:id])
-  end
     
-  def set_user
-    @address = Address.find(params[:id])
-  end
 end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,37 +1,40 @@
-.card
-  .card__title
-    クレジットカード情報
-
-  .card__display
-    - if @card.present?
-
-      %ul.card__display__list
-        %li
-          = form_with url: card_path(@card), method: :delete, local: true, id: 'charge-form' do |f|
-            -# カードブランドのアイコンを表示する場合-----
-            %figure
-              = image_tag "credit_brand/#{@card_src}", width: '68', height: '40', alt: @card_brand, id: "card_image"
-            -#----------------------------------
-            .card__display__list--pay-num
-              = "**** **** **** " + @card_information.last4
-            .card__display__list--pay-num
-              - exp_month = @card_information.exp_month.to_s
-              - exp_year = @card_information.exp_year.to_s.slice(2,3)
-              = exp_month + " / " + exp_year
-            %input{type: "hidden", name: "card_id", value: ""}
-            .card__btn
-              = f.submit "削除する", {class: "card__display__list__remove"}
-              - if flash[:notice]
-                .alert.alert-success
-                = flash[:notice]
-              - if flash[:alert]
-                .alert.alert-dange
-                = flash[:alert]
-    - else
-      .card__display__add
-        = link_to new_card_path, class: "card__btn", data: {"turbolinks" => false} do
-          %i
-          = icon('fas', 'credit-card', class: "card__icon")
-          クレジットカードを追加する
-          -# カードが登録されていない場合は登録ボタンを表示するようにしています。
-  
+.container 
+  .left-content  
+    .card
+      .card__title
+        クレジットカード情報
+    
+      .card__display
+        - if @card.present?
+    
+          %ul.card__display__list
+            %li
+              = form_with url: user_card_path(current_user, @card), method: :delete, local: true, id: 'charge-form' do |f|
+                -# カードブランドのアイコンを表示する場合-----
+                %figure
+                  = image_tag "credit_brand/#{@card_src}", width: '68', height: '40', alt: @card_brand, id: "card_image"
+                -#----------------------------------
+                .card__display__list--pay-num
+                  = "**** **** **** " + @card_information.last4
+                .card__display__list--pay-num
+                  - exp_month = @card_information.exp_month.to_s
+                  - exp_year = @card_information.exp_year.to_s.slice(2,3)
+                  = exp_month + " / " + exp_year
+                %input{type: "hidden", name: "card_id", value: ""}
+                .card__btn
+                  = f.submit "削除する", {class: "card__display__list__remove"}
+                  - if flash[:notice]
+                    .alert.alert-success
+                    = flash[:notice]
+                  - if flash[:alert]
+                    .alert.alert-dange
+                    = flash[:alert]
+        - else
+          .card__display__add
+            = link_to new_user_card_path, class: "card__btn", data: {"turbolinks" => false} do
+              %i
+              = icon('fas', 'credit-card', class: "card__icon")
+              クレジットカードを追加する
+              -# カードが登録されていない場合は登録ボタンを表示するようにしています。
+  .right-content
+    = render "users/right-content"

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -23,12 +23,7 @@
                 %input{type: "hidden", name: "card_id", value: ""}
                 .card__btn
                   = f.submit "削除する", {class: "card__display__list__remove"}
-                  - if flash[:notice]
-                    .alert.alert-success
-                    = flash[:notice]
-                  - if flash[:alert]
-                    .alert.alert-dange
-                    = flash[:alert]
+                  = flash[:alert] 
         - else
           .card__display__add
             = link_to new_user_card_path, class: "card__btn", data: {"turbolinks" => false} do
@@ -36,5 +31,6 @@
               = icon('fas', 'credit-card', class: "card__icon")
               クレジットカードを追加する
               -# カードが登録されていない場合は登録ボタンを表示するようにしています。
+          = flash[:notice] 
   .right-content
     = render "users/right-content"

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,27 +1,31 @@
-.card
-  = form_with url: cards_path, method: :post, html: { name: "inputForm" } do |f|
-    .card__title
-      クレジットカード情報入力
-    .card__registration__label
-      カード番号
-      .card__registration__label__required
-        必須
-    = f.text_field :card_number, type: 'text', placeholder: '半角数字のみ', maxlength: "16"
-    .card__registration__label
-      有効期限
-      .card__registration__label__required
-        必須
-    .card__registration__expiration
-      = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]],{} , class: 'input-expire'
-      .card__registration__expiration__month
-        月
-      = f.select :exp_year, [["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029],["30",2030]],{} , class: 'input-expire' 
-      .card__registration__expiration__year
-        年
-    .card__registration__label
-      セキュリティコード
-      .card__registration__label__required
-        必須
-    = f.text_field :cvc, type: 'text', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
-    .card__btn#card_token
-      = f.submit '追加する', id: 'token_submit'
+.container 
+  .left-content 
+    .card
+      = form_with url: user_cards_path, method: :post, html: { name: "inputForm" } do |f|
+        .card__title
+          クレジットカード情報入力
+        .card__registration__label
+          カード番号
+          .card__registration__label__required
+            必須
+        = f.text_field :card_number, type: 'text', placeholder: '半角数字のみ', maxlength: "16"
+        .card__registration__label
+          有効期限
+          .card__registration__label__required
+            必須
+        .card__registration__expiration
+          = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]],{} , class: 'input-expire'
+          .card__registration__expiration__month
+            月
+          = f.select :exp_year, [["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029],["30",2030]],{} , class: 'input-expire' 
+          .card__registration__expiration__year
+            年
+        .card__registration__label
+          セキュリティコード
+          .card__registration__label__required
+            必須
+        = f.text_field :cvc, type: 'text', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
+        .card__btn#card_token
+          = f.submit '追加する', id: 'token_submit'
+  .right-content
+    = render "users/right-content"

--- a/app/views/users/_right-content.html.haml
+++ b/app/views/users/_right-content.html.haml
@@ -1,0 +1,42 @@
+%nav.mypage-nav
+  %ul.mypage-nav-list
+    %li
+      = link_to "マイページ", user_path(current_user), class: "mypage-nav-list-item" 
+    %li
+      = link_to "いいね！一覧", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "出品する", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "下書き一覧", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "出品した商品 - 出品中", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "出品した商品 - 取引中", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "出品した商品 - 売却済み", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "購入した商品 - 取引中", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "購入した商品 - 過去の取引", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "評価一覧", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "ガイド", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "お問い合わせ", "#", class: "mypage-nav-list-item" 
+  %h3.mypage-nav-head 設定
+  %ul.mypage-nav-list
+    %li
+      = link_to "プロフィール", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "発送元・お届け先住所変更", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "支払い方法", user_cards_path(current_user), class: "mypage-nav-list-item" 
+    %li
+      = link_to "メール/パスワード", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "本人情報", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "電話番号の確認", "#", class: "mypage-nav-list-item" 
+    %li
+      = link_to "ログアウト", "#", class: "mypage-nav-list-item" 

--- a/app/views/users/_right-content.html.haml
+++ b/app/views/users/_right-content.html.haml
@@ -5,7 +5,7 @@
     %li
       = link_to "いいね！一覧", "#", class: "mypage-nav-list-item" 
     %li
-      = link_to "出品する", "#", class: "mypage-nav-list-item" 
+      = link_to "出品する", new_product_path, class: "mypage-nav-list-item" 
     %li
       = link_to "下書き一覧", "#", class: "mypage-nav-list-item" 
     %li

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,0 @@
-users#show

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,110 @@
+.container
+  .left-content
+    %section.mypage-user-icon
+      .mypage-user-icon__box
+        =link_to "", "#"
+        %figure
+          = image_tag 'icon/member_photo_noimage_thumb.png', :size => "60x60"
+        %h2.bold
+          = @user.nickname
+        .mypage-number
+          %div
+            評価
+            %span.bold 0
+          %div
+            出品数
+            %span.bold 0
+    %section.mypage-tab-container-notification-todo
+      %ul.mypage-tabs
+        %li.active
+          %h3
+            = link_to "お知らせ", "#", class: ""
+            %span.mypage-nav-number.hidden-large
+              15
+        %li
+          %h3
+            = link_to "やることリスト", "#", class: ""
+      .tab-content
+        %ul#mypage-tab-notification.mypage-item-list.tab-pane.active
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 22 時間前
+              %i.icon-arrow-right
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 1 日前
+              %i.icon-arrow-right
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 1 日前
+              %i.icon-arrow-right
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 2 日前
+              %i.icon-arrow-right
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 4 日前
+              %i.icon-arrow-right
+          %li.mypage-go-list
+            = link_to '一覧を見る', '#'
+        %ul#mypage-tab-todo.mypage-item-list.tab-pane
+          %li
+            .mypage-item-link
+              %figure
+                = image_tag 'icon/icon_brand.png', :size => "60x60"
+              .mypage-item-body
+                = link_to "かんたん操作で必ずP300もらえる！", class:"mypage-item-text"
+                %time
+                  %i.icon-time
+                  %span 11 日前
+              %i.icon-arrow-right
+          %li.mypage-go-list
+            %a{:href => "/"} 一覧を見る
+    %section.mypage-tab-container
+      %h2.mypage-tab-head 購入した商品
+      %ul.mypage-tabs
+        %li.active
+          %h3
+            = link_to '取引中', class:"data-toggle"
+        %li
+          %h3
+            = link_to '過去の取引', class:"data-toggle"
+      .tab-content
+        %ul.mypage-tab-transaction-now.mypage-item-list.tab-pane.active
+          %li.mypage-item-not-found.bold 取引中の商品がありません
+        %ul.mypage-tab-transaction-old.mypage-item-list.tab-pane
+          %li.mypage-item-not-found.bold 過去に取引した商品がありません
+  .right-content
+    = render "right-content"
+    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     member do 
       get 'logout'
     end
+    resources :cards, only: [:index, :new, :create, :destroy] 
   end
     
   resources :products do
@@ -30,6 +31,6 @@ Rails.application.routes.draw do
       
     end
   end
-    resources :cards, only: [:index, :new, :create, :destroy] 
+    
 end
 


### PR DESCRIPTION
# what
ユーザーマイページのマークアップと、クレジットカードの登録画面への遷移　
マイページメニューは、右画面に固定　

# why
ユーザ登録後のマイページ画面は必須プロダクトのため。
※現状マイページで可能となっている機能は、必須実装の出品機能とクレジットカードの登録になっています。
なお、今後の進捗によって出品中の商品リストや、購入した商品のリストを確認画面に移行も考えております。

### キャプチャ画面
https://gyazo.com/7d828dbad57a71d614cd068c65e92e45