### PR TITLE
購入後画面追加

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -87,6 +87,29 @@ body  {
       padding: 0;
       &__up{
         height: 300px;
+        &__sold {
+          width: 0;
+          height: 0;
+          border-width: 120px 120px 0 0;
+          border-color: #ea352d transparent;
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: 1;
+          border-style: solid;
+          &__inner{
+            top: -90px;
+            font-size: 30px;
+            position: absolute;
+            left: 0;
+            z-index: 2;
+            color: #fff;
+            transform: rotate(-45deg);
+            letter-spacing: 2px;
+            font-weight: 600;
+          }
+         
+        }
       }
       &__down{
         list-style: none;
@@ -161,8 +184,26 @@ body  {
   line-height: 60px;
   text-align: center;
   font-weight: 600;
-  -webkit-transition: all ease-out .3s;
-  transition: all ease-out .3s;
+  text-decoration: none;
+  width :600px;
+  height :60px;
+  margin: 0 auto;
+
+  
+  a {
+    color: white;
+    text-decoration: none;
+  }
+  
+}
+.disabled-btn  {
+  display: block;
+  margin-top: 16px;
+  background-color: lightslategrey;
+  font-size: 24px;
+  line-height: 60px;
+  text-align: center;
+  font-weight: 600;
   text-decoration: none;
   width :600px;
   height :60px;

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -6,25 +6,31 @@ class PurchaseController < ApplicationController
   before_action :set_payjp_secretkey
 
   def index
+    
     @address = Address.where(user_id: current_user.id).first
     #Payjpから顧客情報を取得し、表示
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-    @card_information = customer.cards.retrieve(@card.card_id)
-    @card_brand = @card_information.brand 
-    case @card_brand
-    when "Visa"
-      @card_src = "visa.png"
-    when "JCB"
-      @card_src = "jcb.png"
-    when "MasterCard"
-      @card_src = "master-card.png"
-    when "American Express"
-      @card_src = "american_express.png"
-    when "Diners Club"
-      @card_src = "dinersclub.png"
-    when "Discover"
-      @card_src = "discover.png"
-    end
+    if @card.present?
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @card_information = customer.cards.retrieve(@card.card_id)
+      @card_brand = @card_information.brand 
+      case @card_brand
+      when "Visa"
+        @card_src = "visa.png"
+      when "JCB"
+        @card_src = "jcb.png"
+      when "MasterCard"
+        @card_src = "master-card.png"
+      when "American Express"
+        @card_src = "american_express.png"
+      when "Diners Club"
+        @card_src = "dinersclub.png"
+      when "Discover"
+        @card_src = "discover.png"
+      end
+    
+    else 
+    
+    end  
   end
 
   def buy

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -30,9 +30,15 @@
     = @product.name
   .product-main-content
     .product-image 
-      .product-image__display
+      .product-image__display 
         .product-image__display__up
           = image_tag @product.pictures.first.image_url, size: "300x300", class: "mainImage"
+          -#製品に関して、"buyer_id"の有無を確認
+          -if @product.buyer_id.present? 
+            -#"buyer_id"がある場合には、追加の記述を行う。
+            .product-image__display__up__sold
+              .product-image__display__up__sold__inner 
+                SOLD
       - @product.pictures.each do |picture|
         %ul.product-image__display__down    
           %li.product-image__display__down-thumb
@@ -93,6 +99,9 @@
   - if @product.user_id == current_user.id   
     .item-buy-btn
       = link_to "編集画面に進む", edit_product_path
+  - elsif @product.buyer_id.present? 
+    .disabled-btn 
+      = link_to "売り切れました",'#'
   - else 
     .item-buy-btn
       = link_to "購入画面に進む", index_product_path

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -34,17 +34,20 @@
       .buyconfirm__wrapper__container
         .buyconfirm__method
           支払方法
-        .buyconfirm__cards__list
-          %figure
-            = image_tag "credit_brand/#{@card_src}",width: '34', height: '20', alt: @card_brand, id: "card_image"
-          .buyconfirm__cards__list__number
-            = "**** **** **** " + @card_information.last4
-          .buyconfirm__cards__list__number
-            有効期限
-            - exp_month = @card_information.exp_month.to_s
-            - exp_year = @card_information.exp_year.to_s.slice(2,3)
-            = exp_month + " / " + exp_year
-
+        - if @card.present?
+          .buyconfirm__cards__list
+            %figure
+              = image_tag "credit_brand/#{@card_src}",width: '34', height: '20', alt: @card_brand, id: "card_image"
+            .buyconfirm__cards__list__number
+              = "**** **** **** " + @card_information.last4
+            .buyconfirm__cards__list__number
+              有効期限
+              - exp_month = @card_information.exp_month.to_s
+              - exp_year = @card_information.exp_year.to_s.slice(2,3)
+              = exp_month + " / " + exp_year
+        - else 
+          .buyconfirm__cards__list
+            = link_to "クレジットカードを登録してください", new_card_path(current_user)
       .buyconfirm__wrapper__container
         .buyconfirm__prefecture
           .buyconfirm__prefecture__title


### PR DESCRIPTION
# what
購入後画面を修正
購入完了後、購入画面にSOLD表示と、購入画面を「売り切れました」と表示

# why
購入後の再度同じ商品が購入されるのを防ぐため
購入後画面をわかりやすく表示

# キャプチャ動画
https://gyazo.com/754e8c2dc227267c2133e6d466ec10ab