### PR TITLE
Top-page-product-index-scroll

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -456,64 +456,103 @@ body {
           }
         }
         .productLists {
-          width: 780px;
           margin: 26px auto;
           display: flex;
-          justify-content: space-around;
-          .productList {
-            width: 220px;
-            display: inline-block;
-            float: left;
-            a {
-              background-color: #fff;
-              display: inline-block;
-            }
-            .productList--img {
+          justify-content: center;
+          // .arrow-btn{
+          //   width: 30px;
+          //   position: relative;
+          //   display: inline-block;
+          //   background-color: black;
+          // }
+          // .arrow-btn::before{
+          //   content: '';
+          //   width: 10px;
+          //   height: 10px;
+          //   border: 5px;
+          //   border-top: solid 5px #5bc0de;
+          //   position: absolute;
+          //   top: 50%;
+          //   margin-top: -4px;
+
+          // }
+          // #next::before{
+          //   -ms-transform: rotate(45deg);
+          //   -webkit-transform: rotate(45deg);
+          //   transform: rotate(45deg);
+          //   border-right: solid 5px #5bc0de;
+          //   left: 0;
+          // }
+          // #prev::before{
+          //   -ms-transform: rotate(-45deg);
+          //   -webkit-transform: rotate(-45deg);
+          //   transform: rotate(-45deg);
+          //   border-left: solid 5px #5bc0de;
+          //   top: 50%;
+          //   right: 0;
+          // }
+
+
+          &__container{
+            width: 880px;
+            display: flex;
+            justify-content: space-between;
+            overflow-x: scroll;
+            .productList {
               width: 220px;
-              height: 150px;
-              position: relative;
-              overflow: hidden;
-              margin: 0;
-              z-index: auto;
-              img {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                width: 100%;
-                z-index: auto;
+              display: inline-block;
+              justify-content: space-between;
+              a {
+                background-color: #fff;
+                display: inline-block;
+              }
+              .productList--img {
+                width: 220px;
                 height: 150px;
-                object-fit: cover;
-              }
-            }
-            .productList--body {
-              background-color: #fff;
-              color: #333;
-              padding: 16px;
-              .name {
+                position: relative;
                 overflow: hidden;
-                line-height: 1.5;
-                font-size: 16px;
-                text-align: left;
-              }
-              .details {
-                font-size: 16px;
-                ul {
-                  display: flex;
-                  align-items: center;
-                  justify-content: space-between;
+                margin: 0;
+                z-index: auto;
+                img {
+                  position: absolute;
+                  top: 0;
+                  left: 0;
+                  right: 0;
+                  bottom: 0;
+                  width: 100%;
+                  z-index: auto;
+                  height: 150px;
+                  object-fit: cover;
                 }
-                p {
-                  font-size: 10px;
+              }
+              .productList--body {
+                background-color: #fff;
+                color: #333;
+                padding: 16px;
+                .name {
+                  overflow: hidden;
+                  line-height: 1.5;
+                  font-size: 16px;
                   text-align: left;
                 }
+                .details {
+                  font-size: 16px;
+                  ul {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                  }
+                  p {
+                    font-size: 10px;
+                    text-align: left;
+                  }
+                }
               }
             }
-          }
-          a {
-            text-decoration: none;
-            position: relative;
+            a {
+              text-decoration: none;
+              position: relative;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -459,40 +459,6 @@ body {
           margin: 26px auto;
           display: flex;
           justify-content: center;
-          // .arrow-btn{
-          //   width: 30px;
-          //   position: relative;
-          //   display: inline-block;
-          //   background-color: black;
-          // }
-          // .arrow-btn::before{
-          //   content: '';
-          //   width: 10px;
-          //   height: 10px;
-          //   border: 5px;
-          //   border-top: solid 5px #5bc0de;
-          //   position: absolute;
-          //   top: 50%;
-          //   margin-top: -4px;
-
-          // }
-          // #next::before{
-          //   -ms-transform: rotate(45deg);
-          //   -webkit-transform: rotate(45deg);
-          //   transform: rotate(45deg);
-          //   border-right: solid 5px #5bc0de;
-          //   left: 0;
-          // }
-          // #prev::before{
-          //   -ms-transform: rotate(-45deg);
-          //   -webkit-transform: rotate(-45deg);
-          //   transform: rotate(-45deg);
-          //   border-left: solid 5px #5bc0de;
-          //   top: 50%;
-          //   right: 0;
-          // }
-
-
           &__container{
             width: 880px;
             display: flex;

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -466,6 +466,7 @@ body {
             overflow-x: scroll;
             .productList {
               width: 220px;
+              margin: 0 10px;
               display: inline-block;
               justify-content: space-between;
               a {

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,7 +1,6 @@
 class TopController < ApplicationController
   def index
-    @product = Product.all
-    @pictures = Picture.all
+    @products = Product.all.includes(:pictures)
     @category_parent_array =  Category.where(ancestry: nil)
   end
 end

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -135,7 +135,6 @@
           %h3.title
             = link_to '新規投稿商品', products_path
             .productLists
-              -# .arrow-btn#prev
               .productLists__container
                 - @products.each do |product|
                   .productList
@@ -153,7 +152,6 @@
                               %i.fa.fa-star.likeIcon
                           %p (税込)
                 %end
-              -# .arrow-btn#next
     %section.pickupContainer
       %h2.head ピックアップブランド
       .productBox

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -134,59 +134,26 @@
           = link_to "", "#"
           %h3.title
             = link_to '新規投稿商品', products_path
-        .productLists
-          .productList
-            = link_to "/products/8" do
-              %figure.productList--img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG"
-              .productList--body
-                %h3.name ee
-                .details
-                  %ul
-                    %li 1000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productList
-            = link_to "/products/3" do
-              %figure.productList--img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-            .productList--body
-              %h3.name product3
-              .details
-                %ul
-                  %li 30000円
-                  %li
-                    %i.fa.fa-star.likeIcon
-                    0
-                %p (税込)
-          .productList
-            = link_to "/products/2" do
-              %figure.productList--img
-                = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
-              .productList--body
-                %h3.name product2
-                .details
-                  %ul
-                    %li 20000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productList
-            = link_to "/products/1" do
-              %figure.productList--img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
-              .productList--body
-                %h3.name product1
-                .details
-                  %ul
-                    %li 10000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      1
-                  %p (税込)
+            .productLists
+              -# .arrow-btn#prev
+              .productLists__container
+                - @products.each do |product|
+                  .productList
+                    = link_to product_path(product.id) do
+                      %figure.productList--img
+                        = image_tag product.pictures.first.image_url
+                      .productList--body
+                        %h3
+                          = product.name
+                        .details
+                          %ul
+                            %li
+                              = product.price
+                            %li
+                              %i.fa.fa-star.likeIcon
+                          %p (税込)
+                %end
+              -# .arrow-btn#next
     %section.pickupContainer
       %h2.head ピックアップブランド
       .productBox
@@ -194,58 +161,59 @@
           = link_to "", "#"
           %h3.title アーカイバ
         .productLists
-          .productList
-            = link_to "/products/8" do
-              %figure.productList--img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG"
-              .productList--body
-                %h3.name ee
-                .details
-                  %ul
-                    %li 1000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productList
-            = link_to "/products/3" do
-              %figure.productList--img
-                = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-              .productList--body
-                %h3.name product3
-                .details
-                  %ul
-                    %li 30000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productList
-            = link_to "/products/2" do
-              %figure.productList--img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
-              .productList--body
-                %h3.name product2
-                .details
-                  %ul
-                    %li 20000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productList
-            = link_to "/products/3" do
-              %figure.productList--img
-                = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
-              .productList--body
-                %h3.name product1
-                .details
-                  %ul
-                    %li 10000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      1
-                  %p (税込)
+          .productLists__container
+            .productList
+              = link_to "/products/8" do
+                %figure.productList--img
+                  = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG"
+                .productList--body
+                  %h3.name ee
+                  .details
+                    %ul
+                      %li 1000円
+                      %li
+                        %i.fa.fa-star.likeIcon
+                        0
+                    %p (税込)
+            .productList
+              = link_to "/products/3" do
+                %figure.productList--img
+                  = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
+                .productList--body
+                  %h3.name product3
+                  .details
+                    %ul
+                      %li 30000円
+                      %li
+                        %i.fa.fa-star.likeIcon
+                        0
+                    %p (税込)
+            .productList
+              = link_to "/products/2" do
+                %figure.productList--img
+                  = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
+                .productList--body
+                  %h3.name product2
+                  .details
+                    %ul
+                      %li 20000円
+                      %li
+                        %i.fa.fa-star.likeIcon
+                        0
+                    %p (税込)
+            .productList
+              = link_to "/products/3" do
+                %figure.productList--img
+                  = image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
+                .productList--body
+                  %h3.name product1
+                  .details
+                    %ul
+                      %li 10000円
+                      %li
+                        %i.fa.fa-star.likeIcon
+                        1
+                    %p (税込)
   %aside.appBanner
     .inner
       %h2.inner__title だれでもかんたん、人生を変えるフリマアプリ


### PR DESCRIPTION
#WHAT
トップページから出品された商品の概要を表示する。
各商品概要から詳細ページに遷移する。
商品概要については、4個を表示し、残りは横スクロールでTopページから参照できるようにする。

#WHY
出品された商品の概要（写真１枚・名前・金額）をトップページでみれるようにする。
トップページから全ての商品概要がみれるようにするが、ページ内の新規商品一覧を横スクロールする形で、
全ての商品情報をコンパクトに、ユーザーに表示されるのが目的

＃ADDITIONAL
当初スクロールではなく、矢印をクリックする事で切り替わることを考えましたが、
スクロールの方がユーザービリティが高いので、スクロールに変更。

矢印は矢印で記載したコードを、次なる追加仕様に使えれば良いと思ったので、一旦コメントアウトしてます。
（最終納品時にコメントアウトを消させてください。）
