### PR TITLE
ログイン確認画面修正

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,5 +1,6 @@
 class CardsController < ApplicationController
   require "payjp"
+  before_action :authenticate_user!
   before_action :set_card, only: [:new, :destroy]
   before_action :set_payjp_secretkey, except: :new
 
@@ -28,6 +29,7 @@ class CardsController < ApplicationController
   end
   
   def new
+    @card = Card.where(user_id: current_user.id).first
     redirect_to action: "index" if @card.present?
   end
 
@@ -49,6 +51,7 @@ class CardsController < ApplicationController
     end
   end
   def destroy #PayjpとCardデータベースを削除します
+    
     if @card.present?
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:index,:show]
   before_action :set_product, only: [:show, :edit, :destroy, :update]
 
   def index

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,35 +1,39 @@
 class PurchaseController < ApplicationController
   
   require "payjp"
+  before_action :authenticate_user!
   before_action :set_card 
   before_action :set_product   #クレジットカードと製品の変数を設定
   before_action :set_payjp_secretkey
 
   def index
+    if @products.buyer_id.presents?
+      @address = Address.where(user_id: current_user.id).first
+      #Payjpから顧客情報を取得し、表示
+      if @card.present?
+        customer = Payjp::Customer.retrieve(@card.customer_id)
+        @card_information = customer.cards.retrieve(@card.card_id)
+        @card_brand = @card_information.brand 
+        case @card_brand
+        when "Visa"
+          @card_src = "visa.png"
+        when "JCB"
+          @card_src = "jcb.png"
+        when "MasterCard"
+          @card_src = "master-card.png"
+        when "American Express"
+          @card_src = "american_express.png"
+        when "Diners Club"
+          @card_src = "dinersclub.png"
+        when "Discover"
+          @card_src = "discover.png"
+        end
+      
+      else 
     
-    @address = Address.where(user_id: current_user.id).first
-    #Payjpから顧客情報を取得し、表示
-    if @card.present?
-      customer = Payjp::Customer.retrieve(@card.customer_id)
-      @card_information = customer.cards.retrieve(@card.card_id)
-      @card_brand = @card_information.brand 
-      case @card_brand
-      when "Visa"
-        @card_src = "visa.png"
-      when "JCB"
-        @card_src = "jcb.png"
-      when "MasterCard"
-        @card_src = "master-card.png"
-      when "American Express"
-        @card_src = "american_express.png"
-      when "Diners Club"
-        @card_src = "dinersclub.png"
-      when "Discover"
-        @card_src = "discover.png"
-      end
-    
-    else 
-    
+      end  
+    else
+      
     end  
   end
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -96,19 +96,18 @@
       = converting_to_jpy(@product.price)
     %span.item-tax (税込)
     %span.item-shipping-fee 送料込み
-  - if @product.user_id == current_user.id   
+  - if @product.buyer_id.present?
+    .disabled-btn
+      = link_to '売り切れました','#'
+  - elsif not user_signed_in?
     .item-buy-btn
-      = link_to "編集画面に進む", edit_product_path
+      = link_to '購入画面に進む', index_product_path
+  - elsif @product.user_id == current_user.id
     .item-buy-btn
-      = link_to '削除', product_path(@product.id), method: :delete
-
-  - elsif @product.buyer_id.present? 
-    .disabled-btn 
-      = link_to "売り切れました",'#'
-  - else 
+      = link_to '編集画面に進む', edit_product_path
+  - else
     .item-buy-btn
-      = link_to "購入画面に進む", index_product_path
-
+      = link_to '購入画面に進む', index_product_path
   .item-description.f14
     %p.item-description-inner
       = @product.explanation

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -47,7 +47,7 @@
               = exp_month + " / " + exp_year
         - else 
           .buyconfirm__cards__list
-            = link_to "クレジットカードを登録してください", new_card_path(current_user)
+            = link_to "クレジットカードを登録してください", new_user_card_path(current_user),data: {"turbolinks" => false}
       .buyconfirm__wrapper__container
         .buyconfirm__prefecture
           .buyconfirm__prefecture__title

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -48,7 +48,7 @@
             %li.listsRight__item.listsRight__item--login
               = link_to "ログイン", new_user_session_path
             %li.listsRight__item.listsRight__item--new
-              = link_to "新規会員登録", new_user_registration_path
+              = link_to "新規会員登録", items_path
   .main
     %section.mainVisual
       .content


### PR DESCRIPTION
# what
ログインしていないユーザが、利用可能な機能を整理
ログインしていない場合、商品閲覧と、商品詳細確認のみできる。

# why 
ログインしていないユーザーが、購入画面まで遷移していたため、コントローラーと、商品詳細画面を修正しました。