### PR TITLE
edited_picture_count

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -187,13 +187,31 @@ $(function () {
     var formData = new FormData($(this).get(0));
     var url = $(this).attr('action')
 
-    // 配列の中の空白を削除した綺麗な配列を新規に作成
-    // files_tidy_array = $.grep(files_array, function (e) {
-    //   return e !== "";
-    // });
+    // 配列の中の"削除"を削除した綺麗な配列を新規に作成
+    files_tidy_array = $.grep(files_array, function (e) {
+      return e !== "";
+    });
+
+    if (files_tidy_array.length == 0) {
+      alert("画像がありません！");
+      $(".submit").removeAttr("disabled")
+      return false;
+    }
+
+    var count = 0;
+
     files_array.forEach(function (file) {
-      // top_back_images→{images→[]}という形で[]内にfileが配列で格納されるようなパラメータに指定
-      formData.append("pictures[images][]", file)
+      //配列の中身の数チェック
+      if (file != "") {
+        //削除されたものでなければカウントUP
+        count++;
+      }
+      //11枚目以降のデータは、ajax送信対象としない
+      if (count > 10) {
+        return;
+      } else{
+        formData.append("pictures[images][]", file)
+      }
     });
 
     if ($(this).attr('class') == "new_product") {

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -25,7 +25,6 @@
         cursor: pointer;
 
       }
- 
     }
   }
 }

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -52,6 +52,10 @@ img {
   display: block;
 }
 
+header {
+  display: block;
+}
+
 body {
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
   margin: 0;
@@ -59,21 +63,19 @@ body {
 
   .pcHeader {
     padding: 0 60px;
-
+    height: 97.547px;
     .headerInner {
       max-width: 1040px;
       width: 100%;
       min-height: 82px;
       margin: 0 auto;
       padding: 15px 0 0;
-
       .mainHeader {
         position: relative;
         display: flex;
         align-items: center;
-
         .icon {
-          padding-bottom: 10px;
+          padding: 0 0 10px 0;
           margin-right: 30px;
           border-radius: 4px;
           a {

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -105,7 +105,7 @@
           ほしかったあの商品に出会えるかもしれません。
         .btn
           = link_to image_tag asset_path("icon/app-store.svg"), class: "aBtn"
-          = link_to image_tag asset_path("/assets/icon/google-play.svg"), class: "gBtn"
+          = link_to image_tag asset_path("icon/google-play.svg"), class: "gBtn"
     %section.topKeyFeatures
       %h2.head FURIMAの特徴
       .items


### PR DESCRIPTION
#WHY
実装バグ・UI崩れを含めた、下記３点を修正の為。
1.トップ画面のUIを修正（隙間を縮小）
2.画像出品・編集において、画像がない状態でも画像以外のデータ（ネスト外のデータ）の作成がされてしまう。
3.画像出品・編集において、10枚上ユーザーが選択した場合、画面上では10枚で表示されるがDBは10枚以上となってしまう。

#WHAT
2,3に対して、JS側で条件外のデータをサーバー側に送信させない制御を実装。
また、誤って2に該当する操作をした場合には、アラートを表示、再送信を可能な状態にした。
3については、フロント画面上で10枚までと文言を記載している為、アラートは出さずに対処。