### PR TITLE
ユーザページと商品詳細画面の修正

### DIFF
--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -7,9 +7,10 @@ body {
   width: 1020px;
   padding:0 0 40px;
   margin: 40px auto 0;
-  
+  display: flex;
+  flex-flow: row-reverse;
   .left-content{
-    float: right;
+
     width: 700px;
     background-color: #ffffff;
     .mypage-user-icon{
@@ -277,7 +278,7 @@ body {
   }
   
   .right-content{
-    float: left;
+  
     width: 280px;
     margin: 0 40px 0 0;
     .mypage-nav {

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -2,52 +2,86 @@ body  {
   background: rgb(245, 245, 245);
 }
 .top-header{
-  height: 100px;
-  background-color: red;
-  padding: 0 250px;
+  padding: 0 60px;
+  background-color: #fff;
   &__containers{
+    width: 100%;
     height: 100%;
-    background-color: blue;
+    max-width: 1040px;
+    min-height: 82px;
     margin: 0 auto;
+    padding: 15px 0 0;
     &__top{
+      position: relative;
       display: flex;
-      justify-content: space-between;
-      height: 50%;
-      &__icon{
-        width: 200px;
-        background-color: rebeccapurple;
+      align-items: center;
+      &__icon {
+        
+        margin-right: 30px;
+        border-radius: 4px;
+        img {
+          width: 140px;
+          height: 100%;
+        }
       }
       &__search{
-        width: 700px;
-        background-color: firebrick;
+        display: flex;
+        margin-left: auto;
+        width: 100%;
+        height: 36px;
+        margin-bottom: 5px;
+        &__box {
+          width: calc(100% - 26px);
+          
+          padding: 0 0 0 5px
+
+        }
+        &__icon {
+          width: 36px;
+          border: 0;
+          cursor: pointer;
+          background-color: #3CCACE;
+          padding: 8px;
+          img {
+            width: 100%;
+            height: 100%;
+          }
+        }
       }
     }
     &__bottom{
+      font-size: 14px;
       display: flex;
-      justify-content: space-between;
-      height: 50%;
+      margin-bottom: 10px;
       &__search{
         display: flex;
-
+        position: relative;
         &__category{
-         background-color:floralwhite ;
-         width: 200px;
+          text-decoration: none;
+          line-height: 38px;
+          padding: 0;
         }
         &__brand{
-          background-color:gold ;
-          width: 200px;
+          display: flex;
+          line-height: 38px;
+          padding: 0 0 0 16px;
         }
       }
       &__user{
         display: flex;
-
-        &__signup{
-          background-color:olivedrab ;
-          width: 100px;
+        margin-left: auto;
+        
+        &__signup a{
+          text-decoration: none;
+          color: #333;
+          line-height: 38px;
+          padding: 0 0 0 16px;
         }
-        &__login{
-          background-color:lime ;
-          width: 100px;
+        &__login a{
+          text-decoration: none;
+          color: #333;
+          line-height: 38px;
+          padding: 0 0 0 16px;
         }
       }
     }
@@ -87,6 +121,11 @@ body  {
       padding: 0;
       &__up{
         height: 300px;
+        .mainImage {
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
         &__sold {
           width: 0;
           height: 0;
@@ -114,7 +153,18 @@ body  {
       &__down{
         list-style: none;
         float: left;
+        width: 60px;
         height: 60px;
+        &__thumb{
+          width: 100%;
+          height: 100%;
+          .thumb {
+            width: 100%;
+            height: 100%;
+            resize: both;
+
+          }
+        }
       }
     }
   }
@@ -123,9 +173,7 @@ body  {
 
 
 .item-detail-table {
-
-  width: 100%;
-  max-width: 360px;
+  width: 300px;
   height: 420px;
   margin: 0 8px 0;
   border-collapse: collapse;
@@ -133,7 +181,7 @@ body  {
 }
 
 .item-detail-table th {
-  width: 39%;
+
   text-align: left;
   font-weight: 400;
   background: #fafafa;
@@ -145,7 +193,7 @@ body  {
 }
 
 .item-detail-table td {
-  width: 61%;
+
   background: #fff;
   border-collapse: collapse;
   border: 1px solid #f5f5f5;
@@ -498,15 +546,16 @@ i[class^='icon-'], i[class*='icon-'] {
 //  line-height: 1.2;
 //}
 
-.top-footer {
+footer {
   height: 420px;
   background-color: #333333;
   color: white;
   padding: 0 250px;
+  position: bottom;
+  
 }
 
 
 .visible-sp {
   display: none;
 }
-

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -33,7 +33,7 @@ class ProductsController < ApplicationController
       end
       # redirect_to request.referrer, notice: 'succeded sending'
       respond_to do |format|
-        format.json
+        format.json 
       end
     else
       @category_parent_array << @category_parent_array = Category.where(ancestry: nil)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -37,7 +37,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   #   process resize_to_fit: [50, 50]
   # end
 
-  process resize_to_fit: [100, 100]
+  # process resize_to_fit: [100, 100]
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -150,6 +150,7 @@
           %input{:name => "comment_id", :type => "hidden", :value => ""}/
           %input{:name => "redirect_url_key", :type => "hidden", :value => ""}/
           %input{:name => "__csrf_value", :type => "hidden", :value => ""}/
+-# 下記、ユーザーのその他出品商品を表示するコードです。サーバサイドで今後実装する際は、使われます。
 -#.media
 -#  %ul.social-media-box
 -#    %li

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -2,23 +2,24 @@
   .top-header__containers
     .top-header__containers__top
       .top-header__containers__top__icon
-        メルカリロゴ
-     
-      .top-header__containers__top__search
-        何かお探しですか?
-    
+        = link_to image_tag(asset_path("logo/logo.png")), root_path
+      %form.top-header__containers__top__search
+        %input.top-header__containers__top__search__box{ name: "key", placeholder: "キーワードから探す"}
+        
+        %button.top-header__containers__top__search__icon{ type: "submit"}
+          = image_tag asset_path("icon/icon-search 1.png")            
     .top-header__containers__bottom
       .top-header__containers__bottom__search
         .top-header__containers__bottom__search__category
-          カテゴリーから探す
+          カテゴリー
         
         .top-header__containers__bottom__search__brand
-          ブランドから探す
+          ブランド
       .top-header__containers__bottom__user         
       - if user_signed_in? 
         .top-header__containers__bottom__user__signup
           =link_to 'マイページ', user_path(current_user.id) 
-          =link_to "仮置き）ログアウト", destroy_user_session_path, method: :delete 
+          =link_to "ログアウト", destroy_user_session_path, method: :delete 
       - else 
         .top-header__containers__bottom__user__signup
           =link_to '新規会員登録', items_path      
@@ -32,7 +33,7 @@
     .product-image 
       .product-image__display 
         .product-image__display__up
-          = image_tag @product.pictures.first.image_url, size: "300x300", class: "mainImage"
+          = image_tag @product.pictures.first.image_url, class: "mainImage"
           -#製品に関して、"buyer_id"の有無を確認
           -if @product.buyer_id.present? 
             -#"buyer_id"がある場合には、追加の記述を行う。
@@ -41,8 +42,8 @@
                 SOLD
       - @product.pictures.each do |picture|
         %ul.product-image__display__down    
-          %li.product-image__display__down-thumb
-            = image_tag picture.image_url, size: "60x60", class:"thumb"
+          %li.product-image__display__down__thumb
+            = image_tag picture.image_url, class:"thumb"
     %table.item-detail-table
       %tbody
         %tr
@@ -104,7 +105,9 @@
       = link_to '購入画面に進む', index_product_path
   - elsif @product.user_id == current_user.id
     .item-buy-btn
-      = link_to '編集画面に進む', edit_product_path
+      = link_to '編集画面に進む', edit_product_path, method: :get
+    .item-buy-btn
+      = link_to '削除', product_path(@product.id), method: :delete
   - else
     .item-buy-btn
       = link_to '購入画面に進む', index_product_path
@@ -152,115 +155,115 @@
           %input{:name => "comment_id", :type => "hidden", :value => ""}/
           %input{:name => "redirect_url_key", :type => "hidden", :value => ""}/
           %input{:name => "__csrf_value", :type => "hidden", :value => ""}/
-.media
-  %ul.social-media-box
-    %li
-      %a.share-btn
-        %i.fab.fa-facebook-square>
-    %li
-      %a.share-btn
-        %i.fab.fa-twitter
-    %li
-      %a.share-btn
-        %i.fab.fa-line
-%section.other
-  %h4.items-box-head 
-    = @product.saler.nickname + "さんのその他の出品"
-  .items-box-content
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥4,800
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥5,500
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥10,000
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥10,000
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥6,300
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥12,000
-%section.related
-  %h42.items-box-head
-    パンツスーツ上下 （レディース） その他の商品
-  .items-box-content
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥10,600
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥14,540
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥3,870
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥3,600
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥18,600
-    .items-box
-      %figure.items-box-photo
-        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
-      .items-box-body
-        %h3.items-box-name テスト
-        .items-box-num
-          .items-box-price ¥4,440
+-#.media
+-#  %ul.social-media-box
+-#    %li
+-#      %a.share-btn
+-#        %i.fab.fa-facebook-square>
+-#    %li
+-#      %a.share-btn
+-#        %i.fab.fa-twitter
+-#    %li
+-#      %a.share-btn
+-#        %i.fab.fa-line
+-#%section.other
+-#  %h4.items-box-head 
+-#    = @product.saler.nickname + "さんのその他の出品"
+-#  .items-box-content
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥4,800
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥5,500
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥10,000
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥10,000
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥6,300
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥12,000
+-#%section.related
+-#  %h42.items-box-head
+-#    パンツスーツ上下 （レディース） その他の商品
+-#  .items-box-content
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥10,600
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥14,540
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥3,870
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥3,600
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥18,600
+-#    .items-box
+-#      %figure.items-box-photo
+-#        = image_tag "/uploads/picture/image/2/deadlift-2.jpg"
+-#      .items-box-body
+-#        %h3.items-box-name テスト
+-#        .items-box-num
+-#          .items-box-price ¥4,440
 
 %nav.bread-crumbs
 
-.top-footer
-  .top-footer__container
-    %ul.top-footer__container__title
+%footer
+  .footer__container
+    %ul.footer__container__title
       メルカリについて 
       %li ヘルプ＆ガイド
       %li プライバシーと利用規約

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -138,7 +138,7 @@
               .productLists__container
                 - @products.each do |product|
                   .productList
-                    = link_to product_path(product.id) do
+                    = link_to product_path(product.id), method: :get do
                       %figure.productList--img
                         -# = image_tag product.pictures.first.image_url
                       .productList--body
@@ -253,4 +253,4 @@
     %p © FURIMA
   .purchaseBtn
     %span.purchaseBtn__text 出品する
-    = link_to image_tag(asset_path("icon/icon_camera.png"), class:"purchaseBtn__icon"), new_product_path
+    = link_to image_tag(asset_path("icon/icon_camera.png"), class:"purchaseBtn__icon"), new_product_path, method: :get

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,31 @@
+.top-header
+  .top-header__containers
+    .top-header__containers__top
+      .top-header__containers__top__icon
+        = link_to image_tag(asset_path("logo/logo.png")), root_path
+      %form.top-header__containers__top__search
+        %input.top-header__containers__top__search__box{ name: "key", placeholder: "キーワードから探す"}
+        
+        %button.top-header__containers__top__search__icon{ type: "submit"}
+          = image_tag asset_path("icon/icon-search 1.png")            
+    .top-header__containers__bottom
+      .top-header__containers__bottom__search
+        .top-header__containers__bottom__search__category
+          カテゴリー
+        
+        .top-header__containers__bottom__search__brand
+          ブランド
+      .top-header__containers__bottom__user         
+      - if user_signed_in? 
+        .top-header__containers__bottom__user__signup
+          =link_to 'マイページ', user_path(current_user.id) 
+          =link_to "ログアウト", destroy_user_session_path, method: :delete 
+      - else 
+        .top-header__containers__bottom__user__signup
+          =link_to '新規会員登録', items_path      
+        .top-header__containers__bottom__user__login
+          =link_to 'ログイン', new_user_session_path
+
 .container
   .left-content
     %section.mypage-user-icon
@@ -107,4 +135,13 @@
           %li.mypage-item-not-found.bold 過去に取引した商品がありません
   .right-content
     = render "right-content"
-    
+
+%nav.bread-crumbs
+
+%footer
+  .footer__container
+    %ul.footer__container__title
+      メルカリについて 
+      %li ヘルプ＆ガイド
+      %li プライバシーと利用規約
+      %li 国  


### PR DESCRIPTION
# what
1 商品詳細画面　商品画質の改善　
   →　carrierwaveでアップロードにリサイズをしていたため、HTML上で、画像比を操作すると 画質が悪くなるため
　　　リサイズを無効にしました。

2 商品詳細ページとマイページにヘッダーとフッターを追加　

3 フォームデータ送信にmethod属性の追加
　
4 商品詳細にて商品ボタンの追加　
# why 
1 商品画像を表示する際に画質がかなり悪く、見栄えが悪かったため

2 メルカリ等のフリマアプリのように、商品詳細画面とユーザページにもヘッダーとフッターを追加したかったため

3 商品の出品と編集、詳細閲覧をする際に初回ロード時に、画像アップロードとマウスホバーで閲覧できる機能が、
　[反映されていないため、getメソッドを使用して、サーバー側にリクエストを送信した。

4 ユーザが出品した商品を削除できる機能の追加　

# キャプチャ画像
![image](https://user-images.githubusercontent.com/65805662/93657204-864f2580-fa6b-11ea-9ef5-825149298669.png)
![image](https://user-images.githubusercontent.com/65805662/93657209-9b2bb900-fa6b-11ea-993b-2587a5a08d7c.png)

