### PR TITLE
詳細画面再度編集

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -489,6 +489,28 @@ body {
                   height: 150px;
                   object-fit: cover;
                 }
+                &__sold {
+                    width: 0;
+                    height: 0;
+                    border-width: 120px 120px 0 0;
+                    border-color: #ea352d transparent;
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    z-index: 1;
+                    border-style: solid;
+                  &__inner {
+                      top: -90px;
+                      font-size: 30px;
+                      position: absolute;
+                      left: 0;
+                      z-index: 2;
+                      color: #fff;
+                      transform: rotate(-45deg);
+                      letter-spacing: 2px;
+                      font-weight: 600;
+                  }
+                }
               }
               .productList--body {
                 background-color: #fff;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -102,7 +102,12 @@
       = link_to '売り切れました','#'
   - elsif not user_signed_in?
     .item-buy-btn
-      = link_to '編集画面に進む', edit_product_path, method: :get 
+      = link_to '購入画面に進む', index_product_path
+  - elsif @product.user_id == current_user.id
+    .item-buy-btn
+      = link_to '編集画面に進む', edit_product_path, method: :get
+    .item-buy-btn
+      = link_to '削除', product_path(@product.id), method: :delete
   - else
     .item-buy-btn
       = link_to '購入画面に進む', index_product_path

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -265,7 +265,7 @@
 %footer
   .footer__container
     %ul.footer__container__title
-      メルカリについて 
+      フリマアプリについて 
       %li ヘルプ＆ガイド
       %li プライバシーと利用規約
       %li 国

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -140,7 +140,13 @@
                   .productList
                     = link_to product_path(product.id), method: :get do
                       %figure.productList--img
-                        -# = image_tag product.pictures.first.image_url
+                        = image_tag product.pictures.first.image_url
+                        -#製品に関して、"buyer_id"の有無を確認
+                        -if product.buyer_id.present? 
+                          -#"buyer_id"がある場合には、追加の記述を行う。
+                          .productList--img__sold
+                            .productList--img__sold__inner 
+                              SOLD
                       .productList--body
                         %h3
                           = product.name

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -141,7 +141,7 @@
 %footer
   .footer__container
     %ul.footer__container__title
-      メルカリについて 
+      フリマアプリについて 
       %li ヘルプ＆ガイド
       %li プライバシーと利用規約
       %li 国  


### PR DESCRIPTION
# what 
1,トップページ売り切れ表示機能　
2,  商品詳細画面、出品者が商品編集と削除できるようにリンクの設置
＃why
1,売り切れ表示をすることで、ユーザーにわかりやすいUIにするため　
2,  前回実装しましたが、コンフリクトが起き、消えてしまったため、再度追加
# キャプチャ
売り切れ表示
https://gyazo.com/387bae550c06c7fd5edc1b544b742870
編集と削除リンク
https://gyazo.com/e8ccd5eb1daf303bedb11a59415cfd1f