### PR TITLE
購入確認画面　導線修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,5 @@
 @import "purchase";
 @import "cards";
 @import "mypage";
+@import "products/creditcards";
+@import "shared";

--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -90,10 +90,22 @@
         padding: 10px; 
       }
     }
-    &__add {
-      font-size: 20px;
-      padding: 30px;
+    &__btn-add {
+      a {
+        text-decoration: none;
+        color: #fff;
+        font-size: 16px;
+        font-weight: bold;
+        line-height: 48px;
+        display: block;
+        text-align: center;
+      }
+      cursor: pointer;
+      width: 345px;
+      margin: 0 auto;
+      border-radius: 4px;
+      background: #2BCCD1;
+      border: 1px solid #2BCCD1;
     }
   }
 }
-

--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -66,7 +66,7 @@
 
   &__btn {
     text-align: center;
-    margin: 50px 0;
+    margin: 50px 0 10px 0;
     input{
       width: 345px;
       margin-bottom: 24px;

--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -102,7 +102,7 @@
       }
       cursor: pointer;
       width: 345px;
-      margin: 0 auto;
+      margin: 50px auto 0 auto;
       border-radius: 4px;
       background: #2BCCD1;
       border: 1px solid #2BCCD1;

--- a/app/assets/stylesheets/products/creditcards.scss
+++ b/app/assets/stylesheets/products/creditcards.scss
@@ -1,0 +1,41 @@
+.creditcard {
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.card__display__btn-back{
+  a {
+    text-decoration: none;
+    color: #fff;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 48px;
+    display: block;
+    text-align: center;
+  }
+  cursor: pointer;
+  width: 345px;
+  margin: 0 auto;
+  border-radius: 4px;
+  background: #bbbbbb;
+  border: 1px solid #bbbbbb;
+}
+
+.btn {
+  text-align: center;
+  margin: 35px 0;
+  input{
+    width:360px;
+    line-height: 48px;
+    font-size: 16px;
+    font-weight: bold;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: center;
+    background: #2BCCD1;
+    border: 1px solid #2BCCD1;
+    color: #fff;
+    margin-bottom: 24px;
+  }
+}

--- a/app/assets/stylesheets/products/creditcards.scss
+++ b/app/assets/stylesheets/products/creditcards.scss
@@ -18,6 +18,6 @@
   width: 345px;
   margin: 0 auto;
   border-radius: 4px;
-  background: #bbbbbb;
-  border: 1px solid #bbbbbb;
+  background: #acacac;
+  border: 1px solid #acacac;
 }

--- a/app/assets/stylesheets/products/creditcards.scss
+++ b/app/assets/stylesheets/products/creditcards.scss
@@ -21,21 +21,3 @@
   background: #bbbbbb;
   border: 1px solid #bbbbbb;
 }
-
-.btn {
-  text-align: center;
-  margin: 35px 0;
-  input{
-    width:360px;
-    line-height: 48px;
-    font-size: 16px;
-    font-weight: bold;
-    border-radius: 4px;
-    cursor: pointer;
-    text-align: center;
-    background: #2BCCD1;
-    border: 1px solid #2BCCD1;
-    color: #fff;
-    margin-bottom: 24px;
-  }
-}

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,17 +1,6 @@
-.header{
-  height: 128px;
-  width: 100%;
-  text-align: center;
-  background: rgb(245, 245, 245);
-
-  &__icon{
-  padding-top: 40px;
-  }
-}
-
 .buyconfirm {
   font-family: "Source Sans Pro", Helvetica, Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-  height: 880px;
+  height: 910px;
   width: 100%;
   background-color: rgb(245, 245, 245);
 
@@ -66,6 +55,31 @@
 
         &__cards__list {
           text-align: center;
+        }
+
+        &__cards__btn {
+          a {
+            text-decoration: none;
+            color: #fff;
+            font-size: 16px;
+            font-weight: bold;
+            line-height: 38px;
+            width: 300px;
+            display: block;
+          }
+          cursor: pointer;
+          text-align: center;
+          margin: 10px 0;
+          border-radius: 4px;
+          background: #2BCCD1;
+          border: 1px solid #2BCCD1;
+        }
+
+        &__cards__comment {
+          text-align: center;
+          font-size: 14px;
+          font-weight: bold;
+          color: red;
         }
 
         &__prefecture {

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -1,0 +1,14 @@
+.header{
+  height: 128px;
+  width: 100%;
+  text-align: center;
+  background: rgb(245, 245, 245);
+
+  &__icon{
+  padding-top: 40px;
+    img {
+      height: 100%;
+      width: 230px;
+    }
+  }
+}

--- a/app/controllers/products/creditcards_controller.rb
+++ b/app/controllers/products/creditcards_controller.rb
@@ -1,0 +1,81 @@
+class Products::CreditcardsController < ApplicationController
+
+  require "payjp"
+  before_action :authenticate_user!
+  before_action :set_product, only: [:index, :new, :create, :destroy]
+  before_action :set_card,    only: [:index, :new, :destroy]
+  before_action :set_payjp_secretkey, except: :new
+
+  def index #Cardのデータpayjpに送り情報を取り出します]
+    if @card.present?
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @card_information = customer.cards.retrieve(@card.card_id)
+      @card_brand = @card_information.brand 
+      case @card_brand
+      when "Visa"
+        @card_src = "visa.png"
+      when "JCB"
+        @card_src = "jcb.png"
+      when "MasterCard"
+        @card_src = "master-card.png"
+      when "American Express"
+        @card_src = "american_express.png"
+      when "Diners Club"
+        @card_src = "dinersclub.png"
+      when "Discover"
+        @card_src = "discover.png"
+      end
+    end
+  end
+
+  def new
+    redirect_to action: :create if @card.present?
+  end
+
+  def create #payjpとCardのデータベース作成を実施します。
+    if params['payjp-token'].blank?
+      redirect_to action: :new
+    else
+      customer = Payjp::Customer.create(
+        email: current_user.email, 
+        card: params['payjp-token'],
+        metadata: {user_id: current_user.id}
+      )
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        redirect_to action: :index
+      else
+        redirect_to action: :new
+      end
+    end
+  end
+
+  def destroy #PayjpとCardデータベースを削除します
+    if @card.present?
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      customer.delete
+      if @card.destroy 
+        redirect_to product_creditcards_path 
+        flash[:notice] = "クレジットカードを削除しました。"
+      else
+        redirect_to product_creditcards_path 
+        flash[:alert] = "クレジットカードを削除できませんでした。"
+      end
+    end
+  end
+
+  private
+
+  def set_product
+    @product = Product.find(params[:product_id])
+  end
+
+  def set_card
+    @card = Card.find_by(user_id: current_user.id)
+  end
+
+  def set_payjp_secretkey
+    Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
+  end
+
+end

--- a/app/controllers/products/creditcards_controller.rb
+++ b/app/controllers/products/creditcards_controller.rb
@@ -55,10 +55,10 @@ class Products::CreditcardsController < ApplicationController
       customer = Payjp::Customer.retrieve(@card.customer_id)
       customer.delete
       if @card.destroy 
-        redirect_to product_creditcards_path 
+        redirect_to action: :index
         flash[:notice] = "クレジットカードを削除しました。"
       else
-        redirect_to product_creditcards_path 
+        redirect_to action: :index
         flash[:alert] = "クレジットカードを削除できませんでした。"
       end
     end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -44,7 +44,7 @@ class PurchaseController < ApplicationController
     #製品のbuyer_idを付与
     @product_buyer= Product.find(params[:id])
     @product_buyer.update( buyer_id: current_user.id)
-    redirect_to purchased_product_path
+    redirect_to product_path
   end
 
   private 

--- a/app/helpers/products/creditcards_helper.rb
+++ b/app/helpers/products/creditcards_helper.rb
@@ -1,0 +1,2 @@
+module Products::CreditcardsHelper
+end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -25,12 +25,13 @@
                   = f.submit "削除する", {class: "card__display__list__remove"}
                   = flash[:alert] 
         - else
-          .card__display__add
-            = link_to new_user_card_path, class: "card__btn", data: {"turbolinks" => false} do
+          .card__display__btn-add
+            = link_to new_user_card_path, data: {"turbolinks" => false} do
               %i
-              = icon('fas', 'credit-card', class: "card__icon")
+              = icon('fas', 'credit-card')
               クレジットカードを追加する
               -# カードが登録されていない場合は登録ボタンを表示するようにしています。
+          %br
           = flash[:notice] 
   .right-content
     = render "users/right-content"

--- a/app/views/products/creditcards/index.html.haml
+++ b/app/views/products/creditcards/index.html.haml
@@ -1,0 +1,40 @@
+= render "shared/header_icon"
+
+.creditcard
+  .card
+    .card__title
+      クレジットカード情報
+
+    .card__display
+      - if @card.present?
+
+        %ul.card__display__list
+          %li
+            = form_with url: product_creditcard_path(current_user, @card), method: :delete, local: true, id: 'charge-form' do |f|
+              %figure
+                = image_tag "credit_brand/#{@card_src}", width: '68', height: '40', alt: @card_brand, id: "card_image"
+              .card__display__list--pay-num
+                = "**** **** **** " + @card_information.last4
+              .card__display__list--pay-num
+                - exp_month = @card_information.exp_month.to_s
+                - exp_year = @card_information.exp_year.to_s.slice(2,3)
+                = exp_month + " / " + exp_year
+              %input{type: "hidden", name: "card_id", value: ""}
+              .card__btn
+                = f.submit "削除する", {class: "card__display__list__remove"}
+                = flash[:alert]
+        .card__display__btn-back
+          = link_to "もどる", index_product_path(@product), {class: "card__display__list__remove"}
+
+      - else
+        .card__display__add
+          = link_to new_product_creditcard_path, class: "card__btn", data: {"turbolinks" => false} do
+            %i
+            = icon('fas', 'credit-card', class: "card__icon")
+            クレジットカードを追加する
+            -# カードが登録されていない場合は登録ボタンを表示するようにしています。
+        = flash[:notice] 
+        %br
+        %br
+        .card__display__btn-back
+          = link_to "もどる", index_product_path(@product)

--- a/app/views/products/creditcards/index.html.haml
+++ b/app/views/products/creditcards/index.html.haml
@@ -27,12 +27,13 @@
           = link_to "もどる", index_product_path(@product), {class: "card__display__list__remove"}
 
       - else
-        .card__display__add
-          = link_to new_product_creditcard_path, class: "card__btn", data: {"turbolinks" => false} do
+        .card__display__btn-add
+          = link_to new_product_creditcard_path, data: {"turbolinks" => false} do
             %i
-            = icon('fas', 'credit-card', class: "card__icon")
+            = icon('fas', 'credit-card')
             クレジットカードを追加する
             -# カードが登録されていない場合は登録ボタンを表示するようにしています。
+        %br
         = flash[:notice] 
         %br
         %br

--- a/app/views/products/creditcards/index.html.haml
+++ b/app/views/products/creditcards/index.html.haml
@@ -10,7 +10,7 @@
 
         %ul.card__display__list
           %li
-            = form_with url: product_creditcard_path(current_user, @card), method: :delete, local: true, id: 'charge-form' do |f|
+            = form_with url: product_creditcard_path(@product, @card), method: :delete, local: true, id: 'charge-form' do |f|
               %figure
                 = image_tag "credit_brand/#{@card_src}", width: '68', height: '40', alt: @card_brand, id: "card_image"
               .card__display__list--pay-num
@@ -21,10 +21,10 @@
                 = exp_month + " / " + exp_year
               %input{type: "hidden", name: "card_id", value: ""}
               .card__btn
-                = f.submit "削除する", {class: "card__display__list__remove"}
+                = f.submit "削除する"
                 = flash[:alert]
         .card__display__btn-back
-          = link_to "もどる", index_product_path(@product), {class: "card__display__list__remove"}
+          = link_to "もどる", index_product_path(@product)
 
       - else
         .card__display__btn-add

--- a/app/views/products/creditcards/new.html.haml
+++ b/app/views/products/creditcards/new.html.haml
@@ -28,3 +28,5 @@
       = f.text_field :cvc, type: 'text', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
       .card__btn#card_token
         = f.submit '追加する', id: 'token_submit'
+      .card__display__btn-back
+        = link_to "もどる", index_product_path(@product)

--- a/app/views/products/creditcards/new.html.haml
+++ b/app/views/products/creditcards/new.html.haml
@@ -1,0 +1,30 @@
+= render "shared/header_icon"
+
+.creditcard
+  .card
+    = form_with url: product_creditcards_path(@product.id), method: :post, html: { name: "inputForm" } do |f|
+      .card__title
+        クレジットカード情報入力
+      .card__registration__label
+        カード番号
+        .card__registration__label__required
+          必須
+      = f.text_field :card_number, type: 'text', placeholder: '半角数字のみ', maxlength: "16"
+      .card__registration__label
+        有効期限
+        .card__registration__label__required
+          必須
+      .card__registration__expiration
+        = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]],{} , class: 'input-expire'
+        .card__registration__expiration__month
+          月
+        = f.select :exp_year, [["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029],["30",2030]],{} , class: 'input-expire' 
+        .card__registration__expiration__year
+          年
+      .card__registration__label
+        セキュリティコード
+        .card__registration__label__required
+          必須
+      = f.text_field :cvc, type: 'text', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
+      .card__btn#card_token
+        = f.submit '追加する', id: 'token_submit'

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -69,7 +69,8 @@
       - if @card.present?
         .buyconfirm__wrapper__btn
           = f.submit "購入する", class:"purchase"
-      - else          
+
+      - else
 
 .pfooter
   .pfooter__top

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,6 +1,4 @@
-.header
-  .header__icon
-    = image_tag asset_path('logo/logo.png'), :size =>'185x49'
+= render "shared/header_icon"
 
 .buyconfirm
   = form_with url: buy_product_path, method: :post, local: true do |f| 
@@ -45,9 +43,13 @@
               - exp_month = @card_information.exp_month.to_s
               - exp_year = @card_information.exp_year.to_s.slice(2,3)
               = exp_month + " / " + exp_year
-        - else 
-          .buyconfirm__cards__list
-            = link_to "クレジットカードを登録してください", new_user_card_path(current_user),data: {"turbolinks" => false}
+          .buyconfirm__cards__btn
+            = link_to "クレジットカードを変更する", product_creditcards_path(@product), data: {"turbolinks" => false}
+        - else
+          .buyconfirm__cards__btn
+            = link_to "クレジットカードを登録する", new_product_creditcard_path(@product), data: {"turbolinks" => false}
+          .buyconfirm__cards__comment
+            購入にはクレジットカード登録が必要です
       .buyconfirm__wrapper__container
         .buyconfirm__prefecture
           .buyconfirm__prefecture__title
@@ -64,8 +66,10 @@
             =@address.user.first_name
             =@address.user.last_name
 
-      .buyconfirm__wrapper__btn
-        = f.submit "購入する", class:"purchase"
+      - if @card.present?
+        .buyconfirm__wrapper__btn
+          = f.submit "購入する", class:"purchase"
+      - else          
 
 .pfooter
   .pfooter__top

--- a/app/views/purchase/purchased.html.haml
+++ b/app/views/purchase/purchased.html.haml
@@ -1,3 +1,0 @@
-%h1 購入が完了しました
-
-= link_to 'トップページに戻る',  root_path, class: ''

--- a/app/views/shared/_header_icon.html.haml
+++ b/app/views/shared/_header_icon.html.haml
@@ -1,0 +1,3 @@
+.header
+  .header__icon
+    = link_to image_tag(asset_path('logo/logo.png')), root_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   end
     
   resources :products do
+    scope module: :products do
+      resources :creditcards, only: [:index, :new, :create, :destroy]
+    end
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }

--- a/test/controllers/products/creditcards_controller_test.rb
+++ b/test/controllers/products/creditcards_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Products::CreditcardsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
以下のように導線を修正
1. 【購入確認画面】「クレジットカードを登録する」をクリックすると、カード登録画面へ遷移する。
2. 【購入確認画面＞カード登録画面】カードを登録すると、登録カード確認画面へ遷移する。
3. 【購入確認画面＞カード登録画面】戻るをクリックすると、購入確認画面へ遷移する。
4. 【購入確認画面＆カード登録画面】ヘッダーアイコンをクリックすると、TOP画面へ遷移する。
5. 【購入確認画面】購入ボタンをクリックすると、商品詳細画面（SOLD OUT）へ遷移する。

# Why
使いやすさ向上のため。考えなくてもユーザーが操作できるようにするため。

# キャプチャ
<a href="https://gyazo.com/ed4e50e8912af4c80584ca24eb986f39"><img src="https://i.gyazo.com/ed4e50e8912af4c80584ca24eb986f39.gif" alt="Image from Gyazo" width="944"/></a>